### PR TITLE
Fix for boolean vector bug NA -> TRUE

### DIFF
--- a/Rserve/src/Rserv.c
+++ b/Rserve/src/Rserv.c
@@ -1123,7 +1123,8 @@ static SEXP decode_to_SEXP(unsigned int **buf, int *UPC)
 			(*UPC)++;
 			i = 0;
 			while (i < vl) {
-				LOGICAL(val)[i] = cb[i];
+				//      LOGICAL(val)[i] = cb[i];
+                LOGICAL(val)[i] = (cb[i] == 1) ? TRUE : ((cb[i] == 0) ? FALSE : NA_LOGICAL);
 				i++;
 			}
 			while ((i & 3) != 0) i++;


### PR DESCRIPTION
When a Boolean vector is passed into Rserve which can have NA
NA is converted to TRUE, this is because the during the parsing we directly assign the values from buffer into logical vector and any non zero values are assumed to be true.

Fix is to properly assign TRUE, FALSE and NA values to logical vector
