### PR TITLE
Windows 10 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@
 *.esproj
 *.sublime-workspace
 *.sublime-project
+
+# Visual Studio artifacts
+.vs/
+*.exe
+x64/
+Debug/
+*.vcxproj.user

--- a/Rserve/R/conn.R
+++ b/Rserve/R/conn.R
@@ -6,7 +6,7 @@ Rserve <- function(debug=FALSE, port=6311, args=NULL) {
       stop("Cannot find ", ffn)
     else {
     fn <- paste("\"", fn, "\"", sep='');
-	if ( port != 6311 ) fn <- paste( fn, "--RS-port", port )
+	fn <- paste( fn, "--RS-port", port )
       if ( !is.null(args) ) fn <- paste(fn, paste(args, collapse=' '))
 
       pad <- paste(R.home(),"\\bin;",sep='')

--- a/Rserve/R/conn.R
+++ b/Rserve/R/conn.R
@@ -5,7 +5,8 @@ Rserve <- function(debug=FALSE, port=6311, args=NULL) {
     if (!nchar(fn) || !file.exists(fn))
       stop("Cannot find ", ffn)
     else {
-      if ( port != 6311 ) fn <- paste( fn, "--RS-port", port )
+    fn <- paste("\"", fn, "\"", sep='');
+	if ( port != 6311 ) fn <- paste( fn, "--RS-port", port )
       if ( !is.null(args) ) fn <- paste(fn, paste(args, collapse=' '))
 
       pad <- paste(R.home(),"\\bin;",sep='')

--- a/Rserve/src/Rserv.c
+++ b/Rserve/src/Rserv.c
@@ -382,7 +382,11 @@ int wfork(int socket, char* parentCmdLine, int idx)
   {
 	  return -1;
   }
-  char buf[128];
+  char *cmdline = (char *)malloc(2048 * sizeof(char));
+  if (cmdline == NULL)
+  {
+	  return -1;
+  }
   size_t rc;
   BOOL bSuccess = FALSE;
   int m;
@@ -392,13 +396,31 @@ int wfork(int socket, char* parentCmdLine, int idx)
   saAttr.bInheritHandle = TRUE;
   saAttr.lpSecurityDescriptor = NULL;
 
+  // Create pipes for sending data to the child process.
+  HANDLE hChildStd_IN_Rd;
+  HANDLE hChildStd_IN_Wr;
+  if (!CreatePipe(&hChildStd_IN_Rd, &hChildStd_IN_Wr, &saAttr, 0))
+	  return -1;
+  if (!SetHandleInformation(hChildStd_IN_Wr, HANDLE_FLAG_INHERIT, 0))
+	  return -1;
+  HANDLE hChildStd_OUT_Rd;
+  HANDLE hChildStd_OUT_Wr;
+  if (!CreatePipe(&hChildStd_OUT_Rd, &hChildStd_OUT_Wr, &saAttr, 0))
+	  return -1;
+  if (!SetHandleInformation(hChildStd_OUT_Wr, HANDLE_FLAG_INHERIT, 0))
+	  return -1;
+
   // Set up members of the STARTUPINFO structure. 
   // This structure specifies the STDIN and STDOUT handles for redirection.
   ZeroMemory (&siStartInfo, sizeof (STARTUPINFO));
   siStartInfo.cb = sizeof (STARTUPINFO);
+  siStartInfo.hStdInput = hChildStd_IN_Rd;
+  siStartInfo.hStdOutput = hChildStd_OUT_Wr;
+  siStartInfo.hStdError = hChildStd_OUT_Wr;
+  siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
 
   //get the module name of the current process
-  if (!GetModuleFileNameA (GetModuleHandle (NULL), modname, 512))
+  if (!GetModuleFileNameA (GetModuleHandle (NULL), modname, 2048))
     {
       rc = GetLastError ();
       return -1;
@@ -410,14 +432,13 @@ int wfork(int socket, char* parentCmdLine, int idx)
 	  winSocks[idx] = socket;
 
   //create the command line
-  sprintf_s (buf, 128, "%d --ppid %d", socket, (int)GetCurrentProcessId());
-  strcat_s (modname, 2048, " --win32child ");
-  strcat_s (modname, 2048, buf);
-  strcat_s (modname, 2048, parentCmdLine);
+  sprintf_s (cmdline, 128, " --win32child --ppid %d", (int)GetCurrentProcessId());
+  strcat_s (cmdline, 2048, parentCmdLine);
 
+  printf("start child process: %s %s\n", modname, cmdline);
   // Create the child process. 
-	bSuccess = CreateProcessA ("rserve",
-						modname,      // command line 
+  bSuccess = CreateProcessA (modname,
+						cmdline,    // command line 
                         NULL,       // process security attributes 
                         NULL,       // primary thread security attributes 
                         TRUE,       // handles are inherited 
@@ -434,12 +455,31 @@ int wfork(int socket, char* parentCmdLine, int idx)
   ReleaseMutex(ghMutex);
   
   free (modname);
+  free (cmdline);
 
 	// If an error occurs, exit the application. 
 	if (!bSuccess)
 	{
 		printf ("CreateProcess Failed.\n");
+		printLastError();
 		return -1;
+	}
+	else
+	{
+		// We want the child process to process the request coming in from socket.
+		// For this to work we need to create a duplicate that is attached to the child process.
+		// The duplication has to be done in the parent process. See doc of WSADuplicateSocket for details.
+		WSAPROTOCOL_INFO pi;
+		DWORD dwBytes;
+		if (WSADuplicateSocket((SOCKET)socket, winPI[idx].dwProcessId, &pi))
+		{
+			int rc = WSAGetLastError();
+			printf("rc_WSADuplicateSocket=%d\n", rc);
+			return -1;
+		}
+		// Write the protocol info of the duplicated socket to the STDIN of the child process.
+		if (!WriteFile(hChildStd_IN_Wr, &pi, sizeof(pi), &dwBytes, NULL))
+			return -1;
 	}
 	printf("create handles... Process = %d Thread = %d \n", (int)winPI[idx].hProcess, (int)winPI[idx].hThread);
 
@@ -3562,42 +3602,34 @@ int main(int argc, char **argv)
 				else
 					MAX_CLIENTS = satoi(argv[++i]);
 			}
+#ifdef WIN32
 			//used only when launching Win32 child process via CreateProcess 
 			if (!strcmp(argv[i] + 2, "win32child")) {
 				iWin32Child = 1;
-				if (i + 1 == argc)
+				// We expect the parent process to send us the duplicated socket for the incoming request by STDIN.
+				WSAPROTOCOL_INFO pi;
+				DWORD dwBytes;
+				HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
+				if (!ReadFile(hStdin, &pi, sizeof(pi), &dwBytes, NULL))
 				{
-					fprintf(stderr, "Missing socket specification for --win32child.\n");
+					printf("Failed to get socket from parent process\n");
+					return -1;
+				}
+
+				SOCKET socket_duplicate = 0;
+				if ((socket_duplicate = WSASocket(pi.iAddressFamily, pi.iSocketType, pi.iProtocol, &pi, 0, 0)) != INVALID_SOCKET)
+				{
+					printf("WSASocket=%d\n", socket_duplicate);
 				}
 				else
 				{
-#ifdef WIN32					
-					socket = atoi(argv[++i]);
-					WSAPROTOCOL_INFO pi;
-
-					if (WSADuplicateSocket((SOCKET)socket, GetCurrentProcessId(), &pi))
-					{
-						int rc = WSAGetLastError();
-						printf("rc_WSADuplicateSocket=%d\n", rc);
-						return -1;
-					}
-
-					SOCKET socket_duplicate = 0;
-					if ((socket_duplicate = WSASocket(pi.iAddressFamily, pi.iSocketType, pi.iProtocol, &pi, 0, 0)) != INVALID_SOCKET)
-					{
-						printf("WSASocket=%d\n", socket_duplicate);
-					}
-					else
-					{
-						int rc = WSAGetLastError();
-						printf("rc_WSASocket=%d\n", rc);
-						return -1;
-					}
-					socket = socket_duplicate;
-
-#endif
+					int rc = WSAGetLastError();
+					printf("rc_WSASocket=%d\n", rc);
+					return -1;
 				}
+				socket = socket_duplicate;
 			}
+#endif
 			if (!strcmp(argv[i] + 2, "ppid")) {
 				if (i + 1 == argc)
 					fprintf(stderr, "Missing parent PID specification for --ppid.\n");

--- a/RserveVisualStudio/RPackage/RPackage.vcxproj
+++ b/RserveVisualStudio/RPackage/RPackage.vcxproj
@@ -90,7 +90,7 @@
 copy $(SolutionDir)$(Platform)\$(Configuration)\*.exe $(SolutionDir)\..\Rserve\inst
 cd $(SolutionDir)\..
 mkdir RServetempLibrary
-R CMD INSTALL  --no-multiarch --no-libs --no-test-load --build --library=RServetempLibrary Rserve 
+R CMD INSTALL  --no-multiarch --no-libs --no-test-load --no-configure --build --library=RServetempLibrary Rserve
 rmdir /s /q RServetempLibrary
 </Command>
       <Outputs>$(SolutiontDir)\..\*.zip</Outputs>
@@ -132,7 +132,7 @@ rmdir /s /q RServetempLibrary
 copy $(SolutionDir)$(Platform)\$(Configuration)\*.exe $(SolutionDir)\..\Rserve\inst
 cd $(SolutionDir)\..
 mkdir RServetempLibrary
-R CMD INSTALL  --no-multiarch --no-libs --no-test-load --build --library=RServetempLibrary Rserve 
+R CMD INSTALL  --no-multiarch --no-libs --no-test-load --no-configure --build --library=RServetempLibrary Rserve
 rmdir /s /q RServetempLibrary</Command>
       <Outputs>$(SolutiontDir)\..\*.zip</Outputs>
     </CustomBuildStep>

--- a/RserveVisualStudio/Rserve/Rserve.vcxproj
+++ b/RserveVisualStudio/Rserve/Rserve.vcxproj
@@ -101,7 +101,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;Win32;_R_;RSERV_DEBUG;NO_CONFIG_H;_SECURE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\..\Rserve\src;$(ProjectDir)..\..\Rserve\src\include;C:\Program Files\Microsoft\R Server\R_SERVER\include;C:\Program Files\Microsoft\R Server\R_SERVER\include\R_ext</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\..\Rserve\src;$(ProjectDir)..\..\Rserve\src\include;C:\Program Files\Microsoft\R Server\R_SERVER\include;C:\Program Files\Microsoft\R Server\R_SERVER\include\R_ext;c:\Program Files\Microsoft\MRO-3.3.2\include\</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/RserveVisualStudio/Rserve/Rserve.vcxproj
+++ b/RserveVisualStudio/Rserve/Rserve.vcxproj
@@ -136,7 +136,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;Win32;_R_;NO_CONFIG_H;_SECURE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\..\Rserve\src;$(ProjectDir)..\..\Rserve\src\include;C:\Program Files\Microsoft\R Server\R_SERVER\include;C:\Program Files\Microsoft\R Server\R_SERVER\include\R_ext</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\..\Rserve\src;$(ProjectDir)..\..\Rserve\src\include;C:\Program Files\Microsoft\R Server\R_SERVER\include;C:\Program Files\Microsoft\R Server\R_SERVER\include\R_ext;c:\Program Files\Microsoft\MRO-3.3.2\include\</AdditionalIncludeDirectories>
       <UndefinePreprocessorDefinitions>
       </UndefinePreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>


### PR DESCRIPTION
Neither the release 9.0.0 not the latest branch worked for me on Windows 10. I started investigating and finally found a fix, along with some other minor fixes (see commit messages). Maybe I should have made multiple pull requests.

The main issue I discovered was the following. When a child process is created, it fails to duplicate the socket with the incoming request.
This throws a [10038 socket error](http://stackoverflow.com/questions/3948164/10038-socket-error).
The reason is that the function WSADuplicateSocket is called in the child process but according to its [doc](https://msdn.microsoft.com/en-us/library/windows/desktop/ms741565(v=vs.85).aspx)
it must be called from the parent process.
[This sample](https://memset.wordpress.com/2010/10/13/win32-api-passing-socket-with-ipc-method/) shows how to do it correctly. They used named pipes to transfer the socket infos to the child process. This is not very elegant as this could cause conflicts with the pipe name. So I used STDIN to communicate from parent to child, as is explained [here](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682499(v=vs.85).aspx).
It seems Windows 10 is more strict about socket duplication as it works on older Windows systems.
I tested my code on a Windows 7 PC and it worked there too.